### PR TITLE
Fix to handle other middleware

### DIFF
--- a/lib/new_relic/absinthe/middleware.ex
+++ b/lib/new_relic/absinthe/middleware.ex
@@ -39,7 +39,7 @@ defmodule NewRelic.Absinthe.Middleware do
     span = {Absinthe.Resolution.path(res), make_ref()}
 
     duration_ms =
-      System.convert_time_unit(end_time_mono - start_time_mono, :native, :milliseconds)
+      System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
 
     attributes = %{
       "absinthe.instrumentation": "resolver_function",
@@ -64,7 +64,7 @@ defmodule NewRelic.Absinthe.Middleware do
     })
 
     NewRelic.report_span(
-      timestamp_ms: System.convert_time_unit(start_time, :native, :milliseconds),
+      timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
       duration_s: duration_ms / 1000,
       name: "#{inspect(resolver_mod)}.#{resolver_fun}/#{resolver_arity}",
       edge: [span: span, parent: :root],

--- a/lib/new_relic/absinthe/middleware.ex
+++ b/lib/new_relic/absinthe/middleware.ex
@@ -3,7 +3,19 @@ defmodule NewRelic.Absinthe.Middleware do
 
   @impl Absinthe.Middleware
 
-  def call(%{middleware: [{{Absinthe.Resolution, :call}, resolver_fn} | _]} = res, _config) do
+  def call(%{middleware: middleware} = res, _config) do
+    res_middleware = middleware |> Enum.find(&match?({{Absinthe.Resolution, :call}, _resolver_fn}, &1))
+    if res_middleware do
+      {_, resolver_fn} = res_middleware
+      instrument(res, resolver_fn)
+    else
+      res
+    end
+  end
+
+  def call(res, _config), do: res
+
+  defp instrument(res, resolver_fn) do
     start_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
@@ -24,8 +36,6 @@ defmodule NewRelic.Absinthe.Middleware do
             ]
     }
   end
-
-  def call(res, _config), do: res
 
   def complete(%{state: :resolved} = res,
         resolver_mfa: {resolver_mod, resolver_fun, resolver_arity},

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule NewRelicAbsinthe.MixProject do
       description: "New Relic Instrumentation adapter for Absinthe",
       version: "0.0.1",
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       name: "New Relic Absinthe",
       package: package(),
@@ -38,4 +39,7 @@ defmodule NewRelicAbsinthe.MixProject do
       {:absinthe_plug, "~> 1.4", only: :test}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/new_relic_absinthe_test.exs
+++ b/test/new_relic_absinthe_test.exs
@@ -8,7 +8,7 @@ defmodule NewRelicAbsintheTest do
     use Absinthe.Schema
 
     def middleware(middleware, _field, _object) do
-      [NewRelic.Absinthe.Middleware] ++ middleware
+      [NewRelic.Absinthe.Middleware, NewRelicAbsintheTest.FakeMiddleware] ++ middleware
     end
 
     query do

--- a/test/support/fake_middleware.ex
+++ b/test/support/fake_middleware.ex
@@ -1,0 +1,9 @@
+defmodule NewRelicAbsintheTest.FakeMiddleware do
+  @behaviour Absinthe.Middleware
+
+  @impl Absinthe.Middleware
+
+  def call(res, _config) do
+    res
+  end
+end


### PR DESCRIPTION
Currently the pattern matching on `call` function can't handle if any
middleware is ahead of the `{Absinthe.Resolution, :call}` middleware.