### PR TITLE
Add config to filter out arguments from logs

### DIFF
--- a/lib/new_relic/absinthe/middleware.ex
+++ b/lib/new_relic/absinthe/middleware.ex
@@ -47,7 +47,7 @@ defmodule NewRelic.Absinthe.Middleware do
     end_time_mono = System.monotonic_time()
     path = Absinthe.Resolution.path(res) |> Enum.join(".")
     type = Absinthe.Type.name(res.definition.schema_node.type, res.schema)
-    args = res.arguments |> Map.to_list()
+    args = filter_arguments(res.arguments) |> Map.to_list()
     span = {Absinthe.Resolution.path(res), make_ref()}
 
     duration_ms = System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
@@ -93,6 +93,16 @@ defmodule NewRelic.Absinthe.Middleware do
 
     res
   end
+
+  defp filter_arguments(arguments) when is_map(arguments) do
+    filter_variables =
+      :new_relic_absinthe
+      |> Application.get_env(:filter_variables, [])
+
+    Map.drop(arguments, filter_variables)
+  end
+
+  defp filter_arguments(arguments), do: arguments
 
   defp instrument_operation(:instrumented_operation, _res), do: :ignore
 


### PR DESCRIPTION
This adds the ability to filter out arguments by some config. Some explanation of why we added this is that one of our products is a chat app, and for compliance reasons we can't have message bodies in the logs, where any engineer can see them. So in our case we just set
```elixir
config :new_relic_absinthe, filter_variables: ~w(body)
```
This matches how the absinthe logger handles it:
```elixir
config :absinthe, Absinthe.Logger, filter_variables: ~w(body)
```
We could _maybe_ leverage the existing Absinthe Logger config in some way, or maybe even use the Absinthe Logger to do the formatting/filtering, but if I remember right (this was from a while ago), I don't think the Absinthe Logger exposes that functionality.

Resolves #14 
